### PR TITLE
Do not log every ethernet-frame containing a vlan_tag

### DIFF
--- a/drivers/net/ethernet/allwinner/gmac/gmac_desc.c
+++ b/drivers/net/ethernet/allwinner/gmac/gmac_desc.c
@@ -49,7 +49,7 @@ int desc_get_tx_status(void *data, struct gmac_extra_stats *x,
 	}
 
 	if (p->desc0.tx.vlan_tag) {
-		printk(KERN_INFO "GMAC TX status: VLAN frame\n");
+		//printk(KERN_INFO "GMAC TX status: VLAN frame\n");
 		x->tx_vlan++;
 	}
 


### PR DESCRIPTION
Because logging every ethernet-frame with a vlan_tag is a bad idea if you want to actually use vlan_tags with more than a few packets per minute.